### PR TITLE
Support for deleting secrets

### DIFF
--- a/pkg/restproxy/rest_proxy.go
+++ b/pkg/restproxy/rest_proxy.go
@@ -103,7 +103,7 @@ func (p *restProxy) handleSecret(w http.ResponseWriter, r *http.Request) {
 
 		w.WriteHeader(http.StatusCreated)
 	case "DELETE":
-		err := p.client.Secrets().Delete(path)
+		err := p.client.Secrets().Versions().Delete(path)
 		if err != nil {
 			writeError(w, err, 0)
 			return


### PR DESCRIPTION
On the `/secrets/raw` route. Because it's on `/raw` it deletes the entire secret.