### PR TITLE
Build the binary in the Dockerfile

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,13 +23,3 @@ archive:
       format: zip
   files:
     - LICENSE
-
-dockers:
-  -
-    goos: linux
-    goarch: amd64
-    binaries:
-      - secrethub-http-proxy
-    image_templates:
-      - "secrethub/http-proxy:{{ .Version }}"
-      - "secrethub/http-proxy:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,20 @@
-FROM alpine
+FROM golang:1.12-alpine as build_base
+WORKDIR /build
+ENV GO111MODULE=on
+RUN apk add --update git
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
 
-COPY secrethub-http-proxy /usr/bin/secrethub-http-proxy
-RUN apk add --no-cache ca-certificates && update-ca-certificates
+FROM build_base as build
+RUN apk add --update make
+COPY . .
+RUN make build
+
+FROM alpine
+COPY --from=build /build/secrethub-http-proxy /usr/bin/secrethub-http-proxy
+RUN apk add --no-cache ca-certificates && \
+    update-ca-certificates
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,14 @@ Get the source code:
 git clone https://github.com/secrethub/secrethub-http-proxy
 ```
 
-Build it using:
+To build the binary from source, use:
 
 ```
 make build
+```
+
+To build the Docker image from scratch, you can use:
+
+```
+docker build -t secrethub-http-proxy .
 ```


### PR DESCRIPTION
This makes the Dockerfile stand-alone instead of depending on
goreleaser to create the binary. You can now build the image with
"go build .".